### PR TITLE
feat(Launcher): autodetect game path

### DIFF
--- a/code/launcher/electron/app.js
+++ b/code/launcher/electron/app.js
@@ -14,6 +14,7 @@ const createWindow = () => {
     height: 850,
     frame: false,
     webPreferences: {
+      webSecurity: process.env.ELECTRON_DEV !== '1',
       nodeIntegration: true,
       preload: (process.env.ELECTRON_DEV === '1') ? path.join(__dirname, 'preload.js') : path.join(process.cwd(), 'resources/preload.js')
     }


### PR DESCRIPTION
Toast = Snackbar

**Implemented:**
- [x] test three commons path to auto-detect game executable file
- [x] show toasts to user when file is detected or not
- [x] prompt user to select file otherwise
- [x] add error/warning/success toasts to be improved for reusability across the entire app

Should wait for #8 before merging this PR.