### PR TITLE
ci(Launcher): build and cache with npm

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,10 @@ on:
     branches:
       - main
       - dev
-  
+
+env:
+  IS_CI: true
+
 jobs:
   build:
     strategy:
@@ -52,6 +55,10 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
+        cache: 'npm'
+        cache-dependency-path: |
+          code/launcher/package-lock.json
+          code/launcher/electron/package-lock.json
 
     - name: 'Generate build'
       run: xmake install -o distrib

--- a/code/launcher/README.md
+++ b/code/launcher/README.md
@@ -12,9 +12,12 @@ git clone https://github.com/tiltedphoques/CyberpunkMP.git
 ```shell
 cd code/launcher
 ```
-3. Install dependencies, it will also run command in `electron/`:
+3. Install dependencies:
 ```shell
-npm run install
+npm install
+cd electron/
+npm install
+cd ..
 ```
 
 ## Development

--- a/code/launcher/package-lock.json
+++ b/code/launcher/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "cpt-launcher",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",

--- a/code/launcher/package.json
+++ b/code/launcher/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "postinstall": "cd electron && npm install",
     "dev": "vite",
     "start": "vite",
     "start:all": "cross-env ELECTRON_DEV=1 npx concurrently --kill-others \"vite\" \"cd electron && npx react-devtools\" \"cd electron && npm run start:electron\"",

--- a/code/launcher/xmake.lua
+++ b/code/launcher/xmake.lua
@@ -7,22 +7,36 @@ target("Launcher")
             local stdout, stderr = os.iorunv(cmd, args)
         end
 
+        local function run_install(cmd)
+            if os.getenv("IS_CI") == "true" then
+                run_command(cmd, {"ci"})
+            else
+                run_command(cmd, {"install"})
+            end
+        end
+
         os.cd("code/launcher")
 
         local npm = is_host("windows") and "npm.cmd" or "npm"
 
         -- Run npm commands in the root directory
-        run_command(npm, {"install"})
-        run_command(npm, {"run", "build:all"})
+        run_install(npm)
+        run_command(npm, {"run", "build"})
 
         local electron_dir = path.join(os.curdir(), "electron")
         if not os.isdir(electron_dir) then
             raise("Electron directory not found: " .. electron_dir)
         end
 
+        os.cd(electron_dir)
+
+        -- Run npm commands in the electron directory
+        run_install(npm)
+        run_command(npm, {"run", "build:electron"})
+
         -- Copy produced files
         local src = path.join(electron_dir, "out", "win-unpacked")
-        local dst = path.join("..", "..", target:installdir("launcher"))
+        local dst = path.join("..", "..", "..", target:installdir("launcher"))
         print(string.format("Copying from %s to %s", src, dst))
         if not os.isdir(src) then
             raise("Source directory not found: " .. src)


### PR DESCRIPTION
**Implemented:**
- [x] restore separate build command (React / Electron)
- [x] use `npm ci` instead of `npm install` only when IS_CI=true (in workflow)
- [x] update README

Should wait for #17 before merging this PR.