### PR TITLE
feat(Server): add WebApi hook for plugins

### DIFF
--- a/code/server/loader/Extensions/EmbedIO.cs
+++ b/code/server/loader/Extensions/EmbedIO.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq.Expressions;
+using System.Reflection;
+using CyberpunkSdk;
+using EmbedIO.WebApi;
+
+namespace Server.Loader.Extensions;
+
+public static class EmbedIoExtensions
+{
+    public static WebApiModule WithController(this WebApiModule webApiModule, PluginWebApiController controller)
+    {
+        Delegate factoryFunc = Expression
+            .Lambda(
+                Expression.Call(
+                    Expression.Constant(controller),
+                    typeof(PluginWebApiController)
+                        .GetMethod("Build")!
+                        .MakeGenericMethod(controller.GetType())
+                    )
+                )
+            .Compile();
+        return (WebApiModule)typeof(WebApiModuleExtensions)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .Single(mi => mi.IsGenericMethod & mi.Name == "WithController" && mi.GetParameters().Length == 2)
+            .MakeGenericMethod(controller.GetType())
+            .Invoke(null, new object[] { webApiModule, factoryFunc.DynamicInvoke(Array.Empty<object>()) });
+    }
+}

--- a/code/server/scripting/CyberpunkSdk/WebApi.cs
+++ b/code/server/scripting/CyberpunkSdk/WebApi.cs
@@ -1,0 +1,14 @@
+﻿using EmbedIO;
+using EmbedIO.WebApi;
+
+namespace CyberpunkSdk;
+
+public interface IWebApiHook
+{
+    public Func<PluginWebApiController> BuildController();
+}
+
+public class PluginWebApiController : WebApiController
+{
+    public Func<T> Build<T>() where T : WebApiController => () => this as T;
+}

--- a/code/server/scripting/EmoteSystem/Plugin.cs
+++ b/code/server/scripting/EmoteSystem/Plugin.cs
@@ -2,7 +2,7 @@
 
 namespace EmoteSystem
 {
-    public class Plugin
+    public class Plugin : IWebApiHook
     {
         public static Plugin Instance { get; set; }
 
@@ -11,8 +11,39 @@ namespace EmoteSystem
             Instance = new Plugin();
         }
 
-        Plugin()
+        public EmoteDto? LastEmote
         {
+            get
+            {
+                lock (_emoteLock)
+                {
+                    return _lastEmote;
+                }
+            }
+            private set
+            {
+                lock (_emoteLock)
+                {
+                    _lastEmote = value;
+                }
+            }
+        }
+
+        private EmoteDto? _lastEmote;
+        private readonly object _emoteLock = new();
+
+        private Plugin()
+        {
+        }
+
+        public void UpdateLastEmote(string username, string emote)
+        {
+            LastEmote = new EmoteDto(username, emote);
+        }
+
+        public Func<PluginWebApiController> BuildController()
+        {
+            return () => new EmoteController(Instance);
         }
     }
 }

--- a/code/server/scripting/EmoteSystem/ServerImpl.cs
+++ b/code/server/scripting/EmoteSystem/ServerImpl.cs
@@ -1,6 +1,7 @@
 ﻿using CurseForge.APIClient.Models.Games;
 using Cyberpunk.Rpc.Client.Plugins;
 using CyberpunkSdk;
+using EmoteSystem;
 
 namespace Cyberpunk.Rpc.Server.Plugins
 {
@@ -17,6 +18,7 @@ namespace Cyberpunk.Rpc.Server.Plugins
 
                 EmoteClient.TriggerEmote(id, player.PuppetId, name);
             }
+            Plugin.Instance.UpdateLastEmote(player.Username, name);
         }
     }
 }

--- a/code/server/scripting/EmoteSystem/WebApi.cs
+++ b/code/server/scripting/EmoteSystem/WebApi.cs
@@ -1,0 +1,30 @@
+﻿using CyberpunkSdk;
+using EmbedIO;
+using EmbedIO.Routing;
+
+namespace EmoteSystem;
+
+public record EmoteDto(string Username, string Emote);
+
+internal class EmoteController : PluginWebApiController
+{
+    private readonly Plugin _plugin;
+
+    internal EmoteController(Plugin plugin)
+    {
+        _plugin = plugin;
+    }
+
+    [Route(HttpVerbs.Get, "/")]
+    public EmoteDto GetLastEmote()
+    {
+        var lastEmote = _plugin.LastEmote;
+
+        if (lastEmote == null)
+        {
+            throw HttpException.NotFound();
+        }
+
+        return lastEmote;
+    }
+}


### PR DESCRIPTION
- add `IWebApiHook` interface for plugins.
- plugin implements a factory `BuildController()` to allow internal DI with controller.
- detect when `IWebApiHook` is declared when listing plugins with Assembly.
- add endpoint `/api/v1/plugins/` to list plugins with a WebApi.
- add controller endpoint `/api/v1/plugins/<name>` in which plugin can add as many endpoints required.

Expect naming convention for plugins to be `<name>System`, lowercase `<name>`.
Example:
`EmoteSystem` ---> `/api/v1/plugins/` ---> `["emote"]`
`EmoteSystem` ---> `/api/v1/plugins/emote/`