### PR TITLE
fix(Client): resolve RTTI type names from the class, not its base

### DIFF
--- a/code/client/Red/TypeInfo/Resolving.hpp
+++ b/code/client/Red/TypeInfo/Resolving.hpp
@@ -20,7 +20,7 @@ struct TypeProxyMapping : public std::false_type {};
 namespace Detail
 {
 template<typename T>
-concept IsTypeNameConst = std::is_convertible_v<T, const char*> || std::is_same_v<T, std::string_view>;
+concept IsTypeNameConst = std::is_same_v<std::remove_cvref_t<T>, const char*> || std::is_convertible_v<T, std::string_view>;
 
 template<typename T>
 concept HasGeneratedTypeName = requires(T*)
@@ -156,15 +156,15 @@ consteval auto GetTypeNameStr()
     {
         constexpr auto name = Detail::ResolveTypeNameBuilder<U>();
 
-        if constexpr (std::is_same_v<std::remove_cvref_t<decltype(name)>, std::string_view>)
-        {
-            return Detail::MakeConstStr<name.size()>(name.data());
-        }
-        else
+        if constexpr (std::is_same_v<std::remove_cvref_t<decltype(name)>, const char*>)
         {
             constexpr auto length = std::char_traits<char>::length(name);
 
             return Detail::MakeConstStr<length>(name);
+        }
+        else
+        {
+            return Detail::MakeConstStr<name.size()>(name.data());
         }
     }
     else if constexpr (Detail::HasTypeNameMapping<U>)


### PR DESCRIPTION
## The bug

`RTTI_DEFINE_CLASS` supplies an explicit name through `nameof_short_type<T>()`, which returns `nameof::cstring<N>` — convertible to `std::string_view`, but not the same type. `IsTypeNameConst` demanded an exact `std::string_view`, so `HasTypeNameBuilder` silently failed its `requires` check and `GetTypeNameStr` fell through to `U::NAME`.

C++ inherits static members, so a class deriving from a generated SDK type picks up its **base class's** `NAME`. `NetworkWorldSystem` derives from `RED4ext::IGameSystem`, so it registered itself as `gameIGameSystem`, and `SystemBuilder::RegisterGetter()` generated `GetGameIGameSystem` instead of `GetNetworkWorldSystem`.

A failing `concept` produces no error and no warning — just a different code path.

## Impact on game 2.31

Script validation fails and RED4ext refuses to start the game:

```
Missing native function 'GetNetworkWorldSystem' in native class 'GameInstance'
  at ...\assets\redscript\World\NetworkWorldSystem.reds:60
Native class 'IGameSystem' has declared base class 'IScriptable' that is different than current one 'gameIGameSystem'
Native class 'Event' has declared base class 'IScriptable' that is different than current one 'redEvent'
... (6 more)
```

Only the first of those carries a source ref, and per `ValidateScripts.cpp` only file-attributed errors populate `faultyScriptFiles` and trigger the abort — the rest are downstream noise from the corrupted registration. All nine disappear with this fix.

This is latent on older patches, where the SDK's `IGameSystem` had no `NAME` to inherit.

## The fix

Both hunks are ported verbatim from Codeware `v1.18.0`'s `lib/Red/TypeInfo/Resolving.hpp`:

- `IsTypeNameConst` accepts anything convertible to `string_view` rather than requiring an exact match
- `GetTypeNameStr`'s branch is inverted to test for `const char*` first — required for the concept change to compile, since the other branch now receives non-`const char*` types

## Verification

Tested on Cyberpunk 2077 **2.31** with RED4ext 1.29.1, Codeware 1.18.0, ArchiveXL 1.26.0, TweakXL 1.11.1, redscript 0.5.31:

- Before: nine validation errors, game refuses to start
- After: zero validation errors, game starts, `NetworkWorldSystem` registers under its own name and `GameInstance.GetNetworkWorldSystem()` resolves

Confirmed by temporary instrumentation in `DescribeType`/`RegisterGetter`:

```
before: DescribeType game system 'gameIGameSystem' -> FOUND
        RegisterGetter 'GetGameIGameSystem' on ScriptGameInstance
after:  DescribeType game system 'NetworkWorldSystem' -> FOUND
        RegisterGetter 'GetNetworkWorldSystem' on ScriptGameInstance
```

## Note

A clean checkout of `main` currently can't build `NetPack` because `protobuf-cpp` is unpinned — see #56. This change is header-only and unrelated to that, but you'll need #56 (or a cached package set) to build it locally.