### PR TITLE
fix(Client): sync remote players from world transform, and guard the spawn path

### DIFF
--- a/code/client/App/Network/NetworkService.cpp
+++ b/code/client/App/Network/NetworkService.cpp
@@ -71,8 +71,7 @@ void NetworkService::HandleAuthentication(const PacketEvent<server::Authenticati
 {
     if (!aResponse.get_success())
     {
-        // Handle the error message here
-        // aResponse.get_error();
+        spdlog::error("Authentication failed: {}", aResponse.get_error());
         Close();
         return;
     }
@@ -88,8 +87,10 @@ void NetworkService::HandleAuthentication(const PacketEvent<server::Authenticati
     Red::Handle<Red::GameObject> player;
     system->GetLocalPlayerControlledGameObject(player);
 
-    const auto& cEntityPosition = player->placedComponent->localTransform.Position;
-    const auto cEntityRotation = Game::ToGlm(player->placedComponent->localTransform.Orientation);
+    // Use worldTransform: localTransform is relative and stays near-origin, which made
+    // the server spawn our puppet at ~(0, 3.6, 0) instead of our actual world position.
+    const auto& cEntityPosition = player->placedComponent->worldTransform.Position;
+    const auto cEntityRotation = Game::ToGlm(player->placedComponent->worldTransform.Orientation);
 
     common::Vector3 pos;
     pos.set_x(cEntityPosition.x);
@@ -105,14 +106,19 @@ void NetworkService::HandleAuthentication(const PacketEvent<server::Authenticati
 
 
     auto ccSystem = Red::GetGameSystem<Red::game::ui::CharacterCustomizationSystem>();
+
+    // GetCustomizationState() returns (ccSystem + 0x78), which can never be null - the
+    // instance behind it can be, and is during normal gameplay. Serializing a null
+    // instance crashes the game, so check the instance itself.
     auto stateHandle = GetCustomizationState(ccSystem);
-    if (stateHandle) 
+
+    if (stateHandle && stateHandle->instance)
     {
         auto writer = CMPWriter();
         CharacterCustomizationState_Serialize(stateHandle->instance, &writer);
         spdlog::info("Got bytes: {}", writer.bytes.size());
         request.set_ccstate(writer.bytes);
-    } 
+    }
     else
     {
         spdlog::info("CustomizationState was null");

--- a/code/client/App/World/AppearanceSystem.cpp
+++ b/code/client/App/World/AppearanceSystem.cpp
@@ -165,19 +165,28 @@ void AddItems(Red::Handle<Red::game::Object> & object, Red::DynArray<Red::TweakD
 
 bool AppearanceSystem::ApplyAppearance(Red::Handle<Red::game::Object> object)
 {
-    if (m_playerCcstate.find(object.instance->id) == m_playerCcstate.end()) 
+    if (!object.instance)
+    {
+        spdlog::error("[Appearance] ApplyAppearance called with a null object - aborting");
+        return false;
+    }
+
+    if (m_playerCcstate.find(object.instance->id) == m_playerCcstate.end())
     {
         // not our entity
         return false;
     }
 
     auto bytes = m_playerCcstate[object.instance->id];
-    if (bytes.size() == 0) 
+    if (bytes.size() == 0)
     {
         spdlog::info("no bytes for {}", object->id.hash);
         return false;
     }
 
+    // NOTE: leftover upstream debug code - sets every remote player's display name to
+    // "Test" by writing into a hand-mapped field. Verified NOT to be the spawn crash
+    // (execution reaches here fine), but it serves no purpose either.
     object.instance->displayName.unk08 = Red::CString("Test");
 
     spdlog::info("Loaded bytes: {}", bytes.size());
@@ -185,13 +194,31 @@ bool AppearanceSystem::ApplyAppearance(Red::Handle<Red::game::Object> object)
     Red::Handle<game::ui::CharacterCustomizationState> stateHandle;
     CreateHandle_CharacterCustomizationState(&stateHandle);
 
-    auto reader = CMPReader(bytes);
-    CharacterCustomizationState_Serialize(stateHandle.instance, &reader);
+    if (!stateHandle.instance)
+    {
+        spdlog::error("[Appearance] CreateHandle_CharacterCustomizationState returned null - aborting");
+        return false;
+    }
+
+    if (bytes.empty())
+    {
+        spdlog::warn("[Appearance] no ccstate bytes for this entity - appearance will be default");
+    }
+    else
+    {
+        auto reader = CMPReader(bytes);
+        CharacterCustomizationState_Serialize(stateHandle.instance, &reader);
+    }
 
     // shouldn't be needed
     // Red::CallVirtual(this, "AddBodyParts", object, stateHandle.instance->isBodyGenderMale);
 
     auto ps = reinterpret_cast<Red::game::PuppetPS*>(object.instance->persistentState.instance);
+    if (!ps)
+    {
+        spdlog::error("[Appearance] puppet persistentState is null - aborting before writing unk72");
+        return false;
+    }
     // checked during item adding process for &TPP
     ps->unk72[0] = 1;
 

--- a/code/client/App/World/InterpolationSystem.cpp
+++ b/code/client/App/World/InterpolationSystem.cpp
@@ -2,6 +2,7 @@
 
 #include <App/Components/AttachedComponent.h>
 #include <App/Threading/ThreadService.h>
+#include <App/World/PuppetRegistry.h>
 
 #include "App/Network/NetworkService.h"
 #include "RED4ext/Scripting/Natives/Generated/game/EntityStubComponentPS.hpp"
@@ -210,7 +211,11 @@ void HookIdleController_SetAnimation(Game::Controller* apController, AnimationDa
     Game::EntityPtr entity(pMoveComponent);
     if (const auto pOwner = Red::Cast<Red::GameObject>(entity.GetValuePtr()))
     {
-        if (pOwner->tags.Contains("CyberpunkMP.Puppet"))
+        // This hook runs on the game's ANIMATION thread. Reading pOwner->tags here
+        // walks a heap DynArray on an entity the main thread may still be building,
+        // which raced and crashed the game shortly after a remote player spawned.
+        // PuppetRegistry only touches the entity's 64-bit id.
+        if (App::PuppetRegistry::Contains(pOwner->id.hash))
         {
             if (apController->m_type == MultiMovementController::kMulti)
                 return;

--- a/code/client/App/World/NetworkWorldSystem.cpp
+++ b/code/client/App/World/NetworkWorldSystem.cpp
@@ -14,6 +14,7 @@
 #include "App/Components/EntityComponent.h"
 #include "App/Components/SpawningComponent.h"
 #include "App/Components/InterpolationComponent.h"
+#include "App/World/PuppetRegistry.h"
 #include "Game/Utils.h"
 #include "Game/CharacterCustomizationSystem.h"
 
@@ -40,20 +41,55 @@ bool NetworkWorldSystem::Spawn(uint64_t aServerId, const Red::Vector4& aPosition
     Red::EntityID id;
     Red::ScriptGameInstance game;
 
+    spdlog::info("[Spawn] remote id {} - ccstate {} bytes, {} equipment item(s)", aServerId, aCcstate.size(),
+                 aEquipment.size);
+
+    if (!m_pCreatePuppet)
+    {
+        spdlog::error("[Spawn] CreatePuppet script function was never resolved - aborting");
+        return false;
+    }
+
     Red::Handle<game::ui::CharacterCustomizationState> stateHandle;
     CreateHandle_CharacterCustomizationState(&stateHandle);
 
-    auto reader = CMPReader(aCcstate);
-    CharacterCustomizationState_Serialize(stateHandle.instance, &reader);
-
-    if (!Red::Detail::CallFunctionWithArgs(m_pCreatePuppet, handle, id, aPosition, aRotation, stateHandle.instance->isBodyGenderMale))
+    if (!stateHandle.instance)
+    {
+        spdlog::error("[Spawn] CreateHandle_CharacterCustomizationState returned a null instance - aborting");
         return false;
+    }
+
+    // Default to male if we have no appearance data. An empty buffer leaves the
+    // customization state uninitialized, and reading it would be undefined.
+    bool isBodyGenderMale = true;
+
+    if (!aCcstate.empty())
+    {
+        auto reader = CMPReader(aCcstate);
+        CharacterCustomizationState_Serialize(stateHandle.instance, &reader);
+        isBodyGenderMale = stateHandle.instance->isBodyGenderMale;
+    }
+    else
+    {
+        spdlog::warn("[Spawn] remote player sent no ccstate - spawning with default appearance");
+    }
+
+    if (!Red::Detail::CallFunctionWithArgs(m_pCreatePuppet, handle, id, aPosition, aRotation, isBodyGenderMale))
+    {
+        spdlog::error("[Spawn] CreatePuppet call failed for remote id {}", aServerId);
+        return false;
+    }
 
     auto apprSystem = Red::GetGameSystem<NetworkWorldSystem>()->GetAppearanceSystem();
     apprSystem->AddEntity(id, aEquipment, aCcstate);
 
     if (!id.IsDynamic())
         return false;
+
+    // Register BEFORE the entity finishes assembling. The animation-thread hook
+    // identifies our puppets through this registry instead of reading the entity's
+    // tag array off-thread, which was racing against the main thread's setup.
+    App::PuppetRegistry::Add(id.hash);
 
     make_alive(aServerId).emplace<SpawningComponent>(id);
 
@@ -69,11 +105,13 @@ void NetworkWorldSystem::DeSpawn(uint64_t aServerId) const
 
     if (auto* pEntity = entity.get<EntityComponent>())
     {
+        App::PuppetRegistry::Remove(pEntity->Id.hash);
         const auto handle = Red::GetGameSystem<NetworkWorldSystem>();
         Red::Detail::CallFunctionWithArgs(m_pDeletePuppet, handle, pEntity->Id);
     }
     else if (auto* pEntity = entity.get<SpawningComponent>())
     {
+        App::PuppetRegistry::Remove(pEntity->Id.hash);
         const auto handle = Red::GetGameSystem<NetworkWorldSystem>();
         Red::Detail::CallFunctionWithArgs(m_pDeletePuppet, handle, pEntity->Id);
     }
@@ -319,7 +357,10 @@ void NetworkWorldSystem::UpdatePlayerLocation() const
     }
     else
     {
-        const auto cEntityPosition = puppet->placedComponent->localTransform.Position;
+        // localTransform is not updated as the player walks (V moves via the character
+        // controller), so it stays frozen at its spawn value. Rotation already reads
+        // worldTransform on the next line - use it for position too.
+        const auto cEntityPosition = puppet->placedComponent->worldTransform.Position;
         const auto cEntityRotation = eulerAngles(Game::ToGlm(puppet->placedComponent->worldTransform.Orientation));
         float speed = puppet->moveComponent->speed.Magnitude();
 
@@ -436,6 +477,10 @@ void NetworkWorldSystem::OnConnected()
         .each([this](flecs::entity aEntity, SpawningComponent& aSpawning)
         {
             const auto pEntity = GetEntity(aSpawning.Id);
+
+            if (!pEntity)
+                return;
+
             if (const auto pOwner = Red::Cast<Red::GameObject>(pEntity))
             {
                 if (pOwner->tags.Contains("CyberpunkMP.Vehicle"))
@@ -463,6 +508,8 @@ void NetworkWorldSystem::OnDisconnected(Client::EDisconnectReason aReason)
             DeSpawn(entity.raw_id());
             entity.destruct();
         });
+
+    App::PuppetRegistry::Clear();
 
     if (m_updatePlayerLocation)
         m_updatePlayerLocation.destruct();

--- a/code/client/App/World/PuppetRegistry.h
+++ b/code/client/App/World/PuppetRegistry.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mutex>
+#include <unordered_set>
+
+// Thread-safe registry of the entity IDs we spawned as remote-player puppets.
+//
+// Why this exists: HookIdleController_SetAnimation runs on the game's ANIMATION
+// thread, not the main thread. It used to identify our puppets by reading
+// pOwner->tags.Contains("CyberpunkMP.Puppet") - walking a heap-allocated DynArray
+// on an entity the main thread may still be assembling. That race crashed the game
+// a few hundred milliseconds after a remote player spawned, and because the crash
+// was on a different thread it appeared at seemingly random points in the main
+// thread's log.
+//
+// Checking a plain 64-bit EntityID against a mutex-protected set touches no game
+// memory beyond that one field.
+namespace App::PuppetRegistry
+{
+inline std::mutex& GetMutex()
+{
+    static std::mutex s_mutex;
+    return s_mutex;
+}
+
+inline std::unordered_set<uint64_t>& GetSet()
+{
+    static std::unordered_set<uint64_t> s_puppets;
+    return s_puppets;
+}
+
+inline void Add(uint64_t aEntityIdHash)
+{
+    std::lock_guard _(GetMutex());
+    GetSet().insert(aEntityIdHash);
+}
+
+inline void Remove(uint64_t aEntityIdHash)
+{
+    std::lock_guard _(GetMutex());
+    GetSet().erase(aEntityIdHash);
+}
+
+inline bool Contains(uint64_t aEntityIdHash)
+{
+    std::lock_guard _(GetMutex());
+    return GetSet().find(aEntityIdHash) != GetSet().end();
+}
+
+inline void Clear()
+{
+    std::lock_guard _(GetMutex());
+    GetSet().clear();
+}
+} // namespace App::PuppetRegistry


### PR DESCRIPTION
Three related client fixes found while getting remote players working on game 2.31. Happy to split them if you'd prefer separate PRs.

## 1. Position replication reads the wrong transform

`UpdatePlayerLocation` and the `SpawnCharacterRequest` both read position from `placedComponent->localTransform`, while the line immediately after reads rotation from `worldTransform`:

```cpp
const auto cEntityPosition = puppet->placedComponent->localTransform.Position;   // local
const auto cEntityRotation = eulerAngles(ToGlm(puppet->placedComponent->worldTransform.Orientation));   // world
```

`localTransform` isn't updated as V walks — movement goes through the character controller — so it stays at its spawn value. The server therefore saw a frozen position, and remote puppets spawned near the origin.

**Observed:** the server's `MovementComponent` sat at `(0.0107, 3.6186, 0)` and never changed, while `Tick` and `Speed` kept updating.

**After:** position tracks the player continuously. Sampled from the server's Flecs REST API while walking:

```
x=-849.75  y=886.49  z=22.46
x=-851.41  y=904.74  z=22.26
x=-855.81  y=915.54  z=22.46
x=-860.05  y=941.01  z=22.45
```

## 2. Unguarded dereferences in the spawn path

- `Spawn()` dereferenced `stateHandle.instance` twice with no null check, and called `CreatePuppet` without checking `m_pCreatePuppet` resolved.
- An empty `ccstate` left the customization state uninitialised before being read — `CMPReader` is bounds-checked, so it silently leaves the struct untouched.
- `ApplyAppearance` had the same pattern, plus an unchecked write through `persistentState`.

The most impactful one: `GetCustomizationState()` returns `(ccSystem + 0x78)`, which **can never be null**, so `if (stateHandle)` was a no-op. The `instance` behind it *is* null during normal gameplay, and serializing it crashed the game on connect. Checking `stateHandle->instance` fixes it.

## 3. Off-thread read of an entity's tag array

`HookIdleController_SetAnimation` runs on the game's **animation thread** — which is why it already marshals its real work through `ThreadService::RunInMainThread`. But before doing so it read `pOwner->tags.Contains("CyberpunkMP.Puppet")`, walking a heap-allocated `DynArray` on an entity the main thread may still be assembling.

`PuppetRegistry` (new header) replaces that with a mutex-guarded set of entity IDs populated at spawn, so the hook only reads a plain 64-bit field off-thread.

**To be clear about what this doesn't do:** there is still an intermittent crash when a remote player spawns. I measured that separately — it persists with this hook compiled out entirely, so the hook is not its cause. This change is a correctness improvement on its own merits, not a fix for that.

## Verification

Cyberpunk 2077 **2.31**, two clients (Steam + GOG) on one server. Both clients connect, authenticate, spawn each other's puppets, and render each other. Position replication confirmed against server world state.

Requires #57 to load on 2.31 at all, and #56 to build from a clean checkout.