### PR TITLE
build(SdkGenerator): upgrade CppSharp and retarget to net9.0

### DIFF
--- a/code/server/scripting/SdkGenerator/SdkGenerator.csproj
+++ b/code/server/scripting/SdkGenerator/SdkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x64</PlatformTarget>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CppSharp" Version="1.1.5.3168" />
+    <PackageReference Include="CppSharp" Version="1.1.84.17100" />
     <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

`SdkGenerator` pins `CppSharp 1.1.5.3168`, whose bundled Clang is too old for the MSVC 14.44 STL. On a current toolchain the build fails with:

```
error STL1000: Unexpected compiler version, expected Clang 19.0.0 or newer
```

## Fix

Upgrade to `CppSharp 1.1.84.17100`, which ships a new enough Clang. That package targets `net9.0` only, so `SdkGenerator` is retargeted to `net9.0` as well.

Scope is deliberately narrow: **only `SdkGenerator`** moves to net9.0. The SDK and plugins stay on net8.0, and CI already installs the .NET 9 SDK, so no workflow change is needed. `SdkGenerator` is a build-time code generator, not something shipped to clients.

## Worth knowing

`SdkGenerator/Program.cs` wraps `Main` in `catch (Exception e) { Console.WriteLine(e); }`, so codegen failures **exit 0**. The build then proceeds and fails later with confusing `namespace 'Internal' does not exist` errors instead of surfacing the real parse error.

That cost me a while to track down. Worth a non-zero exit — happy to raise it separately if you'd like.

## Related

- #56 — Docker deps and the `protobuf-cpp` pin (also needed for a clean-checkout build)
- #57 — RTTI type-name resolution, needed for the mod to load on game 2.31