### PR TITLE
feat: make connection and version problems diagnosable, add compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env and fill in the values, then: docker compose up -d
+#
+#   cp .env.example .env
+
+# Credentials for the server's web/admin API. Release builds refuse to start
+# without them (see code/server/loader/Systems/WebApi.cs).
+#
+# Note the admin API binds 0.0.0.0, so anyone who can reach the port can try
+# these. Use a real password, and don't expose the TCP port to the internet.
+CYBERPUNKMP_ADMIN_USERNAME=admin
+CYBERPUNKMP_ADMIN_PASSWORD=
+
+# Port for game traffic (UDP) and the web API (TCP). Clients connect with
+#   --online --ip=<host> --port=<this>
+CYBERPUNKMP_PORT=11778

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ distrib/*
 code/client/Archives/CyberpunkMP.zip
 Cyberpunk2077.exe*
 imgui.ini
+# Local secrets / runtime state (docker compose)
+.env
+config/
+logs/
+plugins/

--- a/code/client/App/Settings.cpp
+++ b/code/client/App/Settings.cpp
@@ -10,17 +10,33 @@ void Settings::Load()
     if (launchParameters.Contains(RED4ext::CString("-online")))
         settings.enabled = true;
 
+    bool ipFromArgs = false;
+    bool portFromArgs = false;
+
     if (const auto ip = launchParameters.Get("-ip"); ip)
     {
         if (ip->size > 0)
+        {
             settings.ip = (*ip)[0].c_str();
+            ipFromArgs = true;
+        }
     }
 
     if (const auto port = launchParameters.Get("-port"); port)
     {
         if (port->size > 0)
+        {
             settings.port = std::strtoul((*port)[0].c_str(), nullptr, 10) & 0xFFFF;
+            portFromArgs = true;
+        }
     }
+
+    // Report what we actually parsed. The game's parser only fills these in for the
+    // --ip=<addr> / --port=<n> form; "-ip <addr>" produces an empty value list and
+    // silently leaves the defaults in place, which looks identical to a dead server.
+    spdlog::info("Server address: {}:{} (ip {}, port {})", settings.ip, settings.port,
+                 ipFromArgs ? "from launch args" : "DEFAULT - --ip= was not parsed",
+                 portFromArgs ? "from launch args" : "DEFAULT - --port= was not parsed");
 
     if (const auto mods = launchParameters.Get("-mod"); mods)
     {

--- a/code/client/App/World/NetworkWorldSystem.cpp
+++ b/code/client/App/World/NetworkWorldSystem.cpp
@@ -406,6 +406,12 @@ void NetworkWorldSystem::OnInitialize(const RED4ext::JobHandle& aJob)
 void NetworkWorldSystem::Connect()
 {
     auto address = fmt::format("{}:{}", Settings::Get().ip, Settings::Get().port);
+
+    // Log the address we actually dial. The launch arguments must use the
+    // --ip=<addr> --port=<n> form; anything else silently leaves these at their
+    // defaults (127.0.0.1:11778) and the connection times out against your own PC.
+    spdlog::info("Connecting to {}", address);
+
     Core::Container::Get<NetworkService>()->Connect(address);
 }
 

--- a/code/client/Main.cpp
+++ b/code/client/Main.cpp
@@ -40,6 +40,11 @@ void Initialize()
 
 #include "App/Application.h"
 
+// The game version this build has actually been tested against. Bump when the mod
+// is verified on a newer patch.
+constexpr uint8_t kSupportedGameMajor = 2;
+constexpr uint16_t kSupportedGameMinor = 31;
+
 RED4EXT_C_EXPORT bool Main(RED4ext::PluginHandle aHandle, RED4ext::EMainReason aReason, const RED4ext::Sdk* aSdk)
 {
 
@@ -47,6 +52,27 @@ RED4EXT_C_EXPORT bool Main(RED4ext::PluginHandle aHandle, RED4ext::EMainReason a
     {
     case RED4ext::EMainReason::Load:
     {
+        // Report the game version, and say plainly when it isn't one we've tested.
+        // Without this, an unsupported patch shows up as a wall of script validation
+        // errors ("Missing native function ...", "declared base class ... different
+        // than current one ...") that give no hint the game version is the problem.
+        // Warn rather than refuse: a later patch may well work, and blocking it would
+        // be presumptuous.
+        if (aSdk->runtime)
+        {
+            const auto& v = *aSdk->runtime;
+            aSdk->logger->InfoF(aHandle, "Game version %u.%u.%u", v.major, v.minor, v.patch);
+
+            if (v.major != kSupportedGameMajor || v.minor != kSupportedGameMinor)
+            {
+                aSdk->logger->WarnF(aHandle,
+                                    "CyberpunkMP was tested against game %u.%u - you are on %u.%u. "
+                                    "If the game refuses to start with script validation errors, "
+                                    "this mismatch is the likely cause.",
+                                    kSupportedGameMajor, kSupportedGameMinor, v.major, v.minor);
+            }
+        }
+
         Initialize();
 
         App::GApplication = MakeUnique<App::Application>(aHandle, aSdk);

--- a/code/server/native/GameServer.cpp
+++ b/code/server/native/GameServer.cpp
@@ -107,12 +107,20 @@ void GameServer::OnConsume(const void* apData, uint32_t aSize, ConnectionId aCon
 
 void GameServer::OnConnection(ConnectionId aHandle)
 {
-    spdlog::debug("Connection received {:x}", aHandle);
+    // Log at info, with the peer address. At debug level this is invisible by
+    // default, which makes "the client cannot connect" impossible to diagnose:
+    // there is no way to tell a client that never reached us from one that
+    // reached us and failed later.
+    char address[SteamNetworkingIPAddr::k_cchMaxString] = {};
+    const auto info = GetConnectionInfo(aHandle);
+    info.m_addrRemote.ToString(address, sizeof(address), true);
+
+    spdlog::info("Connection received from {} (id {:x})", address, aHandle);
 }
 
 void GameServer::OnDisconnection(ConnectionId aConnectionId, EDisconnectReason aReason)
 {
-    spdlog::debug("Connection ended {:x}", aConnectionId);
+    spdlog::info("Connection {:x} ended (reason {})", aConnectionId, static_cast<uint32_t>(aReason));
 
     auto* pPlayerManager = GetWorld()->get_mut<PlayerManager>();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  server:
+    build: .
+    image: cyberpunkmp-server
+    container_name: cyberpunkmp-server
+    restart: unless-stopped
+
+    # Release builds refuse to start without these - see WebApi.cs.
+    environment:
+      CYBERPUNKMP_ADMIN_USERNAME: ${CYBERPUNKMP_ADMIN_USERNAME:?set this in .env}
+      CYBERPUNKMP_ADMIN_PASSWORD: ${CYBERPUNKMP_ADMIN_PASSWORD:?set this in .env}
+
+    ports:
+      # Game traffic. GameNetworkingSockets is UDP; the same port also serves the
+      # web/admin API over TCP.
+      - "${CYBERPUNKMP_PORT:-11778}:11778/udp"
+      - "${CYBERPUNKMP_PORT:-11778}:11778/tcp"
+
+    volumes:
+      # Config is created on first run - keep it so settings survive a rebuild.
+      - ./config:/app/config
+      # Server-side plugins.
+      - ./plugins:/app/plugins
+      # Logs, so you can read them without entering the container.
+      - ./logs:/app/logs
+
+    # The server needs a console attached: without one, Swan does not register its
+    # ConsoleLogger and WebApi's Logger.UnregisterLogger<ConsoleLogger>() throws
+    # "The logger is not registered" on startup.
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
Four small changes, each from time lost to a failure that produced no useful output. Happy to split if you'd prefer.

## 1. Game version check

Log the game version at load, and warn when it isn't the tested one.

On an unsupported patch the mod currently fails as a wall of script validation errors:

```
Missing native function 'GetNetworkWorldSystem' in native class 'GameInstance'
Native class 'IGameSystem' has declared base class 'IScriptable' that is different than current one 'gameIGameSystem'
Native class 'Event' has declared base class 'IScriptable' that is different than current one 'redEvent'
```

Nothing there says "wrong game version." It cost me hours before I worked that out. Now:

```
Game version 2.31.0
CyberpunkMP was tested against game 2.31 - you are on 2.4.
If the game refuses to start with script validation errors, this mismatch is the likely cause.
```

It **warns rather than refuses** — a later patch may work fine, and hard-blocking would be presumptuous. The supported version is a single `constexpr` in `Main.cpp`.

## 2. Client connection diagnostics

Log the resolved address and the dialled address, and say when the launch arguments weren't parsed:

```
Server address: 100.109.102.127:11778 (ip from launch args, port from launch args)
Connecting to 100.109.102.127:11778
```

The game's parser only populates these for the `--key=value` form. Writing `-ip 1.2.3.4` leaves the value list empty, so `settings.ip` silently stays `127.0.0.1` and the client times out against the player's own machine. From the outside that is indistinguishable from a dead server — two of us lost an evening to it, with a correct-looking IP sitting in the launch script the whole time.

```
Server address: 127.0.0.1:11778 (ip DEFAULT - --ip= was not parsed, port ...)
```

## 3. Server connection observability

`OnConnection` / `OnDisconnection` logged at **debug**, which isn't emitted by default:

```cpp
spdlog::debug("Connection received {:x}", aHandle);
```

So a server operator cannot distinguish a client that **never reached them** from one that reached them and failed later — which is exactly the question you need answered when someone says "I can't connect." Now logged at info, with the peer address:

```
Connection received from 100.80.238.91:52134 (id 3f2a1b)
Connection 3f2a1b ended (reason 2)
```

## 4. Docker Compose

A compose file over the existing Dockerfile, so hosting is one command:

- Requires the admin credentials the server refuses to start without (fails fast with a clear message instead of a `SecurityException` at runtime)
- Publishes UDP (game) and TCP (web API)
- Persists `config/`, `plugins/`, `logs/` on the host so settings survive a rebuild
- Sets `tty: true` — **without a console attached the server crashes on startup**, because Swan doesn't register its `ConsoleLogger` and `WebApi`'s `Logger.UnregisterLogger<ConsoleLogger>()` throws `"The logger is not registered"`. That one is non-obvious and worth encoding in the compose file.

`.env` is gitignored so credentials aren't committed; `.env.example` documents what's needed.

## Verification

Client and server both build. Tested on game 2.31 with two clients connecting over a VPN — the address logging is what finally identified a malformed `--ip=` argument on the remote machine.

Related: #56 (build), #57 (loads on 2.31), #58 (remote players), #59 (SdkGenerator).